### PR TITLE
Allow setting 'parser' in environment.conf

### DIFF
--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -113,6 +113,23 @@ However, the same way as dynamic environments:
 * If a module/hostgroup is removed from the library, it will be removed from
   all the shapshots too, as if they were dynamic environments.
 
+## Parser type
+
+When declaring an environment, use the _parser_ option to set the parser type
+that you want to have enabled in that particular Puppet environment. Example:
+
+```
+$ cat future.yaml
+---
+default: qa
+notitications: higgs@cern.ch
+parser: future
+```
+
+The allowed values are: unset (parser key not declared), current or future.
+
+See [PuppetLabs' documentation](http://cern.ch/go/mb6h) for more information.
+
 ## Which environment should I use for my production service?
 
 Disclaimer: The following tips are inevitably coupled to CERN IT policies so

--- a/src/jens/test/test_update.py
+++ b/src/jens/test/test_update.py
@@ -102,8 +102,10 @@ class UpdateTest(JensTestCase):
             self.assertClone('common/hieradata/%s' % branch)
         self.assertEnvironmentLinks("qa")
         self.assertEnvironmentHasAConfigFile("qa")
+        self.assertEnvironmentHasAConfigFileAndParserSet('qa', None)
         self.assertEnvironmentLinks("production")
         self.assertEnvironmentHasAConfigFile("production")
+        self.assertEnvironmentHasAConfigFileAndParserSet('production', None)
 
     def test_directory_environments_not_enabled_by_default(self):
         self._jens_update()

--- a/src/jens/test/test_update.py
+++ b/src/jens/test/test_update.py
@@ -1118,3 +1118,25 @@ class UpdateTest(JensTestCase):
 
         self._jens_update(hints={'hostgroups': ['yi']})
         self.assertClone('hostgroups/yi/qa', pointsto=new_yi_qa)
+
+    def test_directory_environments_parser_modes(self):
+        self.settings.DIRECTORY_ENVIRONMENTS = True
+        ensure_environment(self.settings, 'noparser', 'qa')
+        ensure_environment(self.settings, 'parserfuture', 'qa', parser='future')
+        ensure_environment(self.settings, 'parsercurrent', 'qa', parser='current')
+        self._jens_update()
+
+        self.assertEnvironmentLinks('noparser')
+        self.assertEnvironmentHasAConfigFile('noparser')
+        self.assertEnvironmentHasAConfigFileAndParserSet('noparser', None)
+        self.assertEnvironmentLinks('parserfuture')
+        self.assertEnvironmentHasAConfigFile('parserfuture')
+        self.assertEnvironmentHasAConfigFileAndParserSet('parserfuture', 'future')
+        self.assertEnvironmentLinks('parsercurrent')
+        self.assertEnvironmentHasAConfigFile('parsercurrent')
+        self.assertEnvironmentHasAConfigFileAndParserSet('parsercurrent', 'current')
+
+    def test_directory_environments_parser_modes_bad_value(self):
+        ensure_environment(self.settings, 'parserbroken', 'qa', parser='broken')
+        self._jens_update(errorsExpected=True)
+        self.assertEnvironmentDoesntExist('parserbroken')

--- a/src/jens/test/testcases.py
+++ b/src/jens/test/testcases.py
@@ -13,6 +13,7 @@ import tempfile
 import time
 
 from string import Template
+from configobj import ConfigObj
 
 from jens.locks import JensLockFactory
 from jens.settings import Settings
@@ -169,6 +170,15 @@ class JensTestCase(unittest.TestCase):
             raise AssertionError("Environment '%s' doesn't have a config file" % environment)
         if not os.stat(conf_file_path).st_size > 0:
             raise AssertionError("Environment '%s''s config file seems empty" % environment)
+
+    def assertEnvironmentHasAConfigFileAndParserSet(self, environment, parser):
+        conf_file_path = "%s/%s/environment.conf" % \
+            (self.settings.ENVIRONMENTSDIR, environment)
+
+        config = ConfigObj(conf_file_path)
+        if config.get('parser', None) != parser:
+            raise AssertionError("Environment '%s''s parser:'s value is not %s" %
+                (environment, parser))
 
     def assertEnvironmentDoesNotHaveAConfigFile(self, environment):
         try:

--- a/src/jens/test/tools.py
+++ b/src/jens/test/tools.py
@@ -41,7 +41,7 @@ def destroy_sandbox(path):
     shutil.rmtree(path)
 
 def ensure_environment(settings, envname, default,
-        modules=[], hostgroups=[], common=[]):
+        modules=[], hostgroups=[], common=[], parser=None):
     environment = {'notifications': 'higgs@example.org'}
     if default is not None:
         environment['default'] = default
@@ -60,6 +60,9 @@ def ensure_environment(settings, envname, default,
     for hostgroup in hostgroups:
         name, override = hostgroup.split(':')
         environment['overrides']['hostgroups'][name] = override
+
+    if parser:
+        environment['parser'] = parser
 
     environment_file = open("%s/%s.yaml" % (settings.ENV_METADATADIR, envname), 'w+')
     yaml.dump(environment, environment_file, default_flow_style=False)


### PR DESCRIPTION
Now it's possible to select the parser type when declaring an environment.

The setting will end up in the corresponding environment.conf.

https://docs.puppetlabs.com/puppet/3.8/reference/config_file_environment.html#parser

Fixes #6