### PR TITLE
Handle AssertionError when doing Git ops

### DIFF
--- a/src/jens/decorators.py
+++ b/src/jens/decorators.py
@@ -48,6 +48,8 @@ def git_exec(f):
             raise JensGitError("No such path %s" % e)
         except InvalidGitRepositoryError as e:
             raise JensGitError("Not a git repository: %s" % e)
+        except AssertionError as e:
+            raise JensGitError("Git operation failed: %s" % e)
         return res
 
     return wrapper

--- a/src/jens/test/test_git_wrapper.py
+++ b/src/jens/test/test_git_wrapper.py
@@ -7,6 +7,7 @@
 
 import os
 import jens.git_wrapper as git_wrapper
+from mock import patch
 from jens.test.testcases import JensTestCase
 from jens.errors import JensGitError
 from jens.test.tools import *
@@ -61,6 +62,12 @@ class GitWrapperTest(JensTestCase):
     def test_fetch_existing_repository(self):
         (bare, user) = create_fake_repository(self.sandbox_path, ['qa'])
         git_wrapper.fetch(user)
+
+    @patch('git.remote.Remote.fetch')
+    def test_fetch_fails_when_assertion_error_is_raised(self, stub):
+        (bare, user) = create_fake_repository(self.sandbox_path, ['qa'])
+        stub.side_effect = AssertionError()
+        self.assertRaises(JensGitError, git_wrapper.fetch, user, prune=True)
 
     def test_fetch_existing_bare_repository_and_prune(self):
         (bare, user) = create_fake_repository(self.sandbox_path, ['qa', 'f'])


### PR DESCRIPTION
git.fetch() seems to raise AssertionError sometimes when fetching
repositories with lots of branches so we have to handle that exception
to avoid a crash (see git/remote.py: 584).

To be investigated what's actually going on (a bug fixed in newer
versions of GitPython?)