### PR TITLE
Migrate from optparse to argparse

### DIFF
--- a/bin/jens-config
+++ b/bin/jens-config
@@ -8,7 +8,7 @@
 
 import os
 import sys
-import optparse
+import argparse
 import logging
 
 from jens.settings import Settings
@@ -16,16 +16,16 @@ from jens.errors import JensError, JensConfigError
 
 def parse_cmdline_args():
     """Parses command line parameters."""
-    parser = optparse.OptionParser()
-    parser.add_option('-c', '--config',
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config',
         help="Configuration file path (defaults to '/etc/jens/main.conf'",
         default="/etc/jens/main.conf")
-    parser.add_option('-s', '--section',
+    parser.add_argument('-s', '--section',
         help="Section of the configuration file (defaults to 'main')",
         default="main")
-    parser.add_option('-k', '--key',
+    parser.add_argument('-k', '--key',
         help="Key of the configuration file")
-    opts, args = parser.parse_args()
+    opts = parser.parse_args()
     if opts.key is None:
         raise JensConfigError("--key is mandatory")
     return opts

--- a/bin/jens-gc
+++ b/bin/jens-gc
@@ -9,7 +9,7 @@
 import sys
 import os
 import logging
-import optparse
+import argparse
 
 import jens.git_wrapper as git
 from jens.errors import JensError, JensLockError
@@ -21,25 +21,24 @@ from jens.decorators import timed
 
 def parse_cmdline_args():
     """Parses command line parameters."""
-    parser = optparse.OptionParser()
-    parser.add_option('-c', '--config',
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config',
                       help="Configuration file path "
                            "(defaults to '/etc/jens/main.conf'",
                       default="/etc/jens/main.conf")
-    parser.add_option('-g', '--aggressive',
+    parser.add_argument('-g', '--aggressive',
                       action="store_true",
                       help="Do it aggressively")
-    parser.add_option('-b', '--bare',
+    parser.add_argument('-b', '--bare',
                       action="store_true",
                       help="Clean up bare repositories")
-    parser.add_option('-l', '--clones',
+    parser.add_argument('-l', '--clones',
                       action="store_true",
                       help="Clean up repositories clones")
-    parser.add_option('-a', '--all',
+    parser.add_argument('-a', '--all',
                       action="store_true",
                       help="Clean up everything")
-    opts, _ = parser.parse_args()
-    return opts
+    return parser.parse_args()
 
 @timed
 def gc_bares(opts):

--- a/bin/jens-gitlab-producer-runner
+++ b/bin/jens-gitlab-producer-runner
@@ -8,7 +8,7 @@
 
 import sys
 import logging
-import optparse
+import argparse
 
 from jens.errors import JensConfigError
 from jens.settings import Settings
@@ -16,16 +16,15 @@ from jens.webapps.gitlabproducer import app
 
 def parse_cmdline_args():
     """Parses command line parameters."""
-    parser = optparse.OptionParser()
-    parser.add_option('-c', '--config',
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config',
                       help="Configuration file path "
                            "(defaults to '/etc/jens/main.conf'",
                       default="/etc/jens/main.conf")
-    parser.add_option('-p', '--port',
+    parser.add_argument('-p', '--port',
                       help="Port number to listen to", type=int,
                       default=8000)
-    opts, _ = parser.parse_args()
-    return opts
+    return parser.parse_args()
 
 def main():
     """Application entrypoint."""

--- a/bin/jens-purge-queue
+++ b/bin/jens-purge-queue
@@ -8,7 +8,7 @@
 
 import sys
 import logging
-import optparse
+import argparse
 
 from jens.errors import JensConfigError
 from jens.errors import JensMessagingError
@@ -17,13 +17,12 @@ from jens.messaging import purge_queue
 
 def parse_cmdline_args():
     """Parses command line parameters."""
-    parser = optparse.OptionParser()
-    parser.add_option('-c', '--config',
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config',
                       help="Configuration file path "
                            "(defaults to '/etc/jens/main.conf'",
                       default="/etc/jens/main.conf")
-    opts, _ = parser.parse_args()
-    return opts
+    return parser.parse_args()
 
 def main():
     """Application entrypoint."""

--- a/bin/jens-reset
+++ b/bin/jens-reset
@@ -8,7 +8,7 @@
 
 import os
 import sys
-import optparse
+import argparse
 import shutil
 import logging
 
@@ -20,16 +20,15 @@ from jens.locks import JensLockFactory
 
 def parse_cmdline_args():
     """Parses command line parameters."""
-    parser = optparse.OptionParser()
-    parser.add_option('-c', '--config',
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config',
                       help="Configuration file path "
                            "(defaults to '/etc/jens/main.conf'",
                       default="/etc/jens/main.conf")
-    parser.add_option('-y', '--yes',
+    parser.add_argument('-y', '--yes',
                       action="store_true",
                       help="Please do it")
-    opts, _ = parser.parse_args()
-    return opts
+    return parser.parse_args()
 
 def remove_bares():
     settings = Settings()

--- a/bin/jens-stats
+++ b/bin/jens-stats
@@ -8,7 +8,7 @@
 
 import os
 import sys
-import optparse
+import argparse
 import logging
 import pprint
 
@@ -21,28 +21,27 @@ from jens.messaging import count_pending_hints
 
 def parse_cmdline_args():
     """Parses command line parameters."""
-    parser = optparse.OptionParser()
-    parser.add_option('-c', '--config',
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config',
                       help="Configuration file path "
                            "(defaults to '/etc/jens/main.conf'",
                       default="/etc/jens/main.conf")
-    parser.add_option('-r', '--repositories',
+    parser.add_argument('-r', '--repositories',
                       action="store_true",
                       help="Shows stats about repositories")
-    parser.add_option('-e', '--environment',
+    parser.add_argument('-e', '--environment',
                       action="store_true",
                       help="Shows stats about environments")
-    parser.add_option('-i', '--inventory',
+    parser.add_argument('-i', '--inventory',
                       action="store_true",
                       help="Shows inventory")
-    parser.add_option('-q', '--queues',
+    parser.add_argument('-q', '--queues',
                       action="store_true",
                       help="Shows stats about queues")
-    parser.add_option('-a', '--all',
+    parser.add_argument('-a', '--all',
                       action="store_true",
                       help="Shows everything")
-    opts, _ = parser.parse_args()
-    return opts
+    return parser.parse_args()
 
 def get_bare_repositories():
     settings = Settings()

--- a/bin/jens-update
+++ b/bin/jens-update
@@ -8,7 +8,7 @@
 
 import sys
 import logging
-import optparse
+import argparse
 
 from jens.errors import JensError, JensLockError
 from jens.errors import JensConfigError, JensRepositoriesError
@@ -24,17 +24,16 @@ from jens.messaging import fetch_update_hints
 
 def parse_cmdline_args():
     """Parses command line parameters."""
-    parser = optparse.OptionParser()
-    parser.add_option('-c', '--config',
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config',
                       help="Configuration file path "
                            "(defaults to '/etc/jens/main.conf'",
                       default="/etc/jens/main.conf")
-    parser.add_option('-p', '--poll',
+    parser.add_argument('-p', '--poll',
                       help="Force POLL mode, regardless of what's "
                            "in the config file",
                       action='store_true')
-    opts, _ = parser.parse_args()
-    return opts
+    return parser.parse_args()
 
 def main():
     """Application entrypoint."""


### PR DESCRIPTION
[Optparse](https://docs.python.org/2/library/optparse.html#module-optparse) is deprecated since 2.7 and 3.2.

This kind of indirectly corrects a bug in `jens-gc`, as before this patch and when not enabling `--aggressive`, `None` was being incorrectly passed to `git.gc()`.  With argparse, if the action of a parameter is `store_true` then the default value is set to `False`.

https://docs.python.org/2.7/library/argparse.html#action