### PR TITLE
Use yaml.safe_load() instead of yaml.load()

### DIFF
--- a/src/jens/environments.py
+++ b/src/jens/environments.py
@@ -200,7 +200,7 @@ def read_environment_definition(environment):
     try:
         path = settings.ENV_METADATADIR + "/%s.yaml" % environment
         logging.debug("Reading environment from %s", path)
-        environment = yaml.load(open(path, 'r'))
+        environment = yaml.safe_load(open(path, 'r'))
         for key in ('notifications',):
             if key not in environment:
                 raise JensEnvironmentsError("Missing '%s' in environment '%s'" %

--- a/src/jens/repos.py
+++ b/src/jens/repos.py
@@ -31,7 +31,7 @@ def refresh_repositories(hints=None):
     settings = Settings()
     try:
         logging.debug("Reading metadata from %s", settings.REPO_METADATA)
-        definition = yaml.load(open(settings.REPO_METADATA, 'r'))
+        definition = yaml.safe_load(open(settings.REPO_METADATA, 'r'))
     except Exception as error:  # fixme
         raise JensRepositoriesError("Unable to parse %s (%s)",
                                     settings.REPO_METADATA, error)

--- a/src/jens/test/tools.py
+++ b/src/jens/test/tools.py
@@ -112,7 +112,7 @@ def init_repositories():
 def add_repository(partition, name, url):
     settings = Settings()
     repositories_file = open(settings.REPO_METADATA, 'r')
-    data = yaml.load(repositories_file)
+    data = yaml.safe_load(repositories_file)
     repositories_file.close()
     data['repositories'][partition][name] = 'file://' + url
     repositories_file = open(settings.REPO_METADATA, 'w+')
@@ -122,7 +122,7 @@ def add_repository(partition, name, url):
 def del_repository(partition, name):
     settings = Settings()
     repositories_file = open(settings.REPO_METADATA, 'r')
-    data = yaml.load(repositories_file)
+    data = yaml.safe_load(repositories_file)
     repositories_file.close()
     del data['repositories'][partition][name]
     repositories_file = open(settings.REPO_METADATA, 'w+')

--- a/src/jens/webapps/gitlabproducer.py
+++ b/src/jens/webapps/gitlabproducer.py
@@ -36,7 +36,7 @@ def hello_gitlab():
         try:
             with open(settings.REPO_METADATA, 'r') as metadata:
                 fcntl.flock(metadata, fcntl.LOCK_SH)
-                repositories = yaml.load(metadata)['repositories']
+                repositories = yaml.safe_load(metadata)['repositories']
                 fcntl.flock(metadata, fcntl.LOCK_UN)
         except Exception as error:
             raise JensError("Could not read '%s' ('%s')"


### PR DESCRIPTION
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Basic YAML should be enough for the documents that Jens reads, namely:

- Environment definitions.
- Repository definitions (`repositories.yaml`).