### PR TITLE
Add support for Gitlab tokens

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -356,6 +356,20 @@ are enqueued:
 INFO 2015-12-10T14:43:01.705468 - hostgroups/foo - '0000003c/56698165ac7909' added to the queue
 ```
 
+Requests can be authenticated using a [secret
+token](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#validate-payloads-by-using-a-secret-token)
+which has to be configured both on the Gitlab side (via the group or
+repository settings) and on the Jens side via:
+
+```ini
+[gitlabproducer]
+secret_token = your_token_here
+```
+
+If there's no token set (default) then all requests will be accepted
+regardless of the presence or the value of the header
+`X-Gitlab-Token`.
+
 ### Setting a timeout for Git operations via SSH
 
 To protect Jens from hanging indefinitely in case of a lack of response from

--- a/conf/main.conf
+++ b/conf/main.conf
@@ -29,3 +29,6 @@ queuedir = /var/spool/jens-update
 
 [git]
 ssh_cmd_path = /etc/jens/myssh.sh
+
+[gitlabproducer]
+secret_token = placeholder

--- a/jens/configfile.py
+++ b/jens/configfile.py
@@ -31,4 +31,6 @@ lockdir = string(default='/run/lock/jens')
 queuedir = string(default='/var/spool/jens-update')
 [git]
 ssh_cmd_path = string(default=None)
+[gitlabproducer]
+secret_token = string(default=None)
 """

--- a/jens/settings.py
+++ b/jens/settings.py
@@ -76,6 +76,9 @@ class Settings(object):
         # [git]
         self.SSH_CMD_PATH = config["git"]["ssh_cmd_path"]
 
+        # [gitlabproducer]
+        self.GITLAB_PRODUCER_SECRET_TOKEN = config["gitlabproducer"]["secret_token"]
+
         if self.logfile:
             logging.basicConfig(
                 level=getattr(logging, self.DEBUG_LEVEL),

--- a/jens/webapps/gitlabproducer.py
+++ b/jens/webapps/gitlabproducer.py
@@ -27,6 +27,13 @@ def hello_gitlab():
         payload = request.get_json(silent=True) or {}
         if payload:
             logging.debug('Incoming request with payload: %s' % str(payload))
+
+        if settings.GITLAB_PRODUCER_SECRET_TOKEN:
+            server_token = request.headers.get('X-Gitlab-Token')
+            if server_token != settings.GITLAB_PRODUCER_SECRET_TOKEN:
+                logging.error("Bad Gitlab Token (%s)", server_token)
+                return 'Unauthorised', 401
+
         try:
             url = payload['repository']['git_ssh_url']
         except (KeyError, TypeError) as error:


### PR DESCRIPTION
This changesets adds a new configuration option to be consumed by the Gitlab producer that, when set, forces the webservice to verify that the request from Gitlab comes from a trusted source.

These changes depend on #42.