### PR TITLE
Allow vague matching when processing Gitlab hooks data

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -356,6 +356,23 @@ are enqueued:
 INFO 2015-12-10T14:43:01.705468 - hostgroups/foo - '0000003c/56698165ac7909' added to the queue
 ```
 
+For the hints to be produced, the URL in the `git_ssh_url` field of
+the payload sent by Gitlab has to be an exact match to the URL of the
+repository configured in the metadata repositories (see setting
+`repositorymetadata`).
+
+However, there's a way to configure the Gitlab producer so a more
+lightweight way of matching is performed. When the configuration
+option `fuzzy_url_prefixes` (in section `[gitlabproducer]`) is set
+(list of strings), each element will be considered a valid prefix for
+the URL reported by Gitlab to start with and then only the
+`namespace/repo.git` part will be actually compared against the data
+in the metadata repositories. This stupid "feature" is just to work
+around a [Gitlab
+bug](https://gitlab.com/gitlab-org/gitlab/-/issues/373793) so it's
+likely you can simply forget about it. If you ever need this, use it
+carefully as bad values could lead to unexpected behaviour.
+
 ### Setting a timeout for Git operations via SSH
 
 To protect Jens from hanging indefinitely in case of a lack of response from

--- a/conf/main.conf
+++ b/conf/main.conf
@@ -29,3 +29,6 @@ queuedir = /var/spool/jens-update
 
 [git]
 ssh_cmd_path = /etc/jens/myssh.sh
+
+[gitlabproducer]
+fuzzy_url_prefixes = git@gitlab.example.org,

--- a/jens/configfile.py
+++ b/jens/configfile.py
@@ -31,4 +31,6 @@ lockdir = string(default='/run/lock/jens')
 queuedir = string(default='/var/spool/jens-update')
 [git]
 ssh_cmd_path = string(default=None)
+[gitlabproducer]
+fuzzy_url_prefixes = list(default=list())
 """

--- a/jens/settings.py
+++ b/jens/settings.py
@@ -76,6 +76,9 @@ class Settings(object):
         # [git]
         self.SSH_CMD_PATH = config["git"]["ssh_cmd_path"]
 
+        # [gitlabproducer]
+        self.GITLAB_PRODUCER_FUZZY_URL_PREFIXES = config["gitlabproducer"]["fuzzy_url_prefixes"]
+
         if self.logfile:
             logging.basicConfig(
                 level=getattr(logging, self.DEBUG_LEVEL),

--- a/jens/test/tools.py
+++ b/jens/test/tools.py
@@ -109,12 +109,13 @@ def init_repositories():
     yaml.dump(data, repositories_file, default_flow_style=False)
     repositories_file.close()
 
-def add_repository(partition, name, url):
+def add_repository(partition, name, url, local=True):
     settings = Settings()
     repositories_file = open(settings.REPO_METADATA, 'r')
     data = yaml.safe_load(repositories_file)
     repositories_file.close()
-    data['repositories'][partition][name] = 'file://' + url
+    data['repositories'][partition][name] = \
+        'file://' + url if local else url
     repositories_file = open(settings.REPO_METADATA, 'w+')
     yaml.dump(data, repositories_file, default_flow_style=False)
     repositories_file.close()

--- a/jens/webapps/test/test_gitlabproducer.py
+++ b/jens/webapps/test/test_gitlabproducer.py
@@ -84,3 +84,150 @@ class GitlabProducerTestCase(JensTestCase):
                         }
                     }))
         self.assertEqual(reply.status_code, 404)
+
+    @patch('jens.webapps.gitlabproducer.enqueue_hint')
+    def test_fuzzy_matching_vague_match(self, mock_eq):
+        """No exact match, matching URL prefix and simplest
+        namespace/repo case. Should find the module.
+        """
+        self.settings.GITLAB_PRODUCER_FUZZY_URL_PREFIXES = ['git@gitlab.example.org:']
+        add_repository('modules', 'module1', \
+                       "ssh://git@gitlab.example.org:1234/name+space-1/it-re_module1.git",
+                       local=False)
+        reply = self.app.post('/gitlab', content_type='application/json',
+                    data=json.dumps({'repository':
+                        {
+                         'name': 'it-re_module1',
+                         'git_ssh_url': "git@gitlab.example.org:name+space-1/it-re_module1.git",
+                        }
+                    }))
+        mock_eq.assert_called_once_with('modules', 'module1')
+        self.assertEqual(reply.status_code, 200)
+
+    @patch('jens.webapps.gitlabproducer.enqueue_hint')
+    def test_fuzzy_matching_vague_match_several_prefixes(self, mock_eq):
+        """No exact match, matching URL prefix (not the first) and
+        simplest namespace/repo case. Makes sure that
+        GITLAB_PRODUCER_FUZZY_URL_PREFIXES is iterated. Should find
+        the module.
+        """
+        self.settings.GITLAB_PRODUCER_FUZZY_URL_PREFIXES = \
+            ['user@gl.example.com', 'git@gitlab.example.org:']
+        add_repository('modules', 'module1', \
+                       "ssh://git@gitlab.example.org:1234/namespace/module1.git",
+                       local=False)
+        reply = self.app.post('/gitlab', content_type='application/json',
+                    data=json.dumps({'repository':
+                        {
+                         'name': 'module1',
+                         'git_ssh_url': "git@gitlab.example.org:namespace/module1.git",
+                        }
+                    }))
+        mock_eq.assert_called_once_with('modules', 'module1')
+        self.assertEqual(reply.status_code, 200)
+
+    @patch('jens.webapps.gitlabproducer.enqueue_hint')
+    # No exact match, matching URL prefix and path with not just
+    # namespace/repo. Should find the repository in the metadata
+    # as the "tail" namespace/repo matches.
+    def test_fuzzy_matching_vague_match_long_path(self, mock_eq):
+        """No exact match, matching URL prefix and path with not just
+        namespace/repo. Should find the repository in the metadata
+        as the "tail" namespace/repo matches.
+        """
+        self.settings.GITLAB_PRODUCER_FUZZY_URL_PREFIXES = ['git@gitlab.example.org:']
+        add_repository('modules', 'module5', \
+                       "ssh://git@gitlab.example.org:1234/foo/namespace/module5.git",
+                       local=False)
+        reply = self.app.post('/gitlab', content_type='application/json',
+                    data=json.dumps({'repository':
+                        {
+                         'name': 'module1',
+                         'git_ssh_url': "git@gitlab.example.org:bar/namespace/module5.git",
+                        }
+                    }))
+        mock_eq.assert_called_once_with('modules', 'module5')
+        self.assertEqual(reply.status_code, 200)
+
+    def test_fuzzy_matching_good_prefix_different_repo(self):
+        """No exact match, hook URL matches a configured prefix but the
+        repository itself is not the correct one, should 404.
+        """
+        self.settings.GITLAB_PRODUCER_FUZZY_URL_PREFIXES = ['git@gitlab.example.org:']
+        add_repository('modules', 'module5', \
+                       "ssh://git@gitlab.example.org:1234/namespace/module5.git",
+                       local=False)
+        reply = self.app.post('/gitlab', content_type='application/json',
+                    data=json.dumps({'repository':
+                        {
+                         'name': 'module55',
+                         'git_ssh_url': "git@gitlab.example.org:namespace/module55.git",
+                        }
+                    }))
+        self.assertEqual(reply.status_code, 404)
+
+    def test_fuzzy_matching_no_valid_prefix(self):
+        """No exact match and no URL prefixes that match either, should 404."""
+        self.settings.GITLAB_PRODUCER_FUZZY_URL_PREFIXES = ['git@gitlab.somewhereelse.org:']
+        add_repository('modules', 'module2', \
+                       "ssh://git@gitlab.somewhereelse.org:1234/namespace/module2.git",
+                       local=False)
+        reply = self.app.post('/gitlab', content_type='application/json',
+                    data=json.dumps({'repository':
+                        {
+                         'name': 'module2',
+                         'git_ssh_url': "git@gitlab.example.org:namespace/module2.git",
+                        }
+                    }))
+        self.assertEqual(reply.status_code, 404)
+
+    @patch('jens.webapps.gitlabproducer.enqueue_hint')
+    def test_fuzzy_matching_not_matching_start_exact_match_nonetheless(self, mock_eq):
+        """Even if a prefix is configured, exact matches should always win."""
+        self.settings.GITLAB_PRODUCER_FUZZY_URL_PREFIXES = ['git@gitlab.foo.org:']
+        add_repository('modules', 'module3', \
+                       "ssh://git@gitlab.example.org:1234/namespace/module3.git",
+                       local=False)
+        reply = self.app.post('/gitlab', content_type='application/json',
+                    data=json.dumps({'repository':
+                        {
+                         'name': 'module3',
+                         'git_ssh_url': "ssh://git@gitlab.example.org:1234/namespace/module3.git",
+                        }
+                    }))
+        mock_eq.assert_called_once_with('modules', 'module3')
+        self.assertEqual(reply.status_code, 200)
+
+    def test_fuzzy_matching_repo_no_tail_exact_match(self):
+        """No exact match and matching URL prefix. Partial match in the
+        namespace/repo combo, but not good enough. Should 404.
+        """
+        self.settings.GITLAB_PRODUCER_FUZZY_URL_PREFIXES = ['git@gitlab.example.org:']
+        add_repository('modules', 'module2', \
+                       "ssh://git@gitlab.example.org:1234/namespace/module2.git",
+                       local=False)
+        reply = self.app.post('/gitlab', content_type='application/json',
+                    data=json.dumps({'repository':
+                        {
+                         'name': 'module2',
+                         'git_ssh_url': "git@gitlab.example.org:namespace/module2",
+                        }
+                    }))
+        self.assertEqual(reply.status_code, 404)
+
+    def test_fuzzy_matching_repo_no_namespace_match(self):
+        """No exact match and matching URL prefix. Good match in repo
+        name but different namespace. Should 404.
+        """
+        self.settings.GITLAB_PRODUCER_FUZZY_URL_PREFIXES = ['git@gitlab.example.org:']
+        add_repository('modules', 'module7', \
+                       "ssh://git@gitlab.example.org:1234/start/module7.git",
+                       local=False)
+        reply = self.app.post('/gitlab', content_type='application/json',
+                    data=json.dumps({'repository':
+                        {
+                         'name': 'module7',
+                         'git_ssh_url': "git@gitlab.example.org:planet/module7.git",
+                        }
+                    }))
+        self.assertEqual(reply.status_code, 404)


### PR DESCRIPTION
This patch adds a new configuration option in section `[gitlabproducer]` called `fuzzy_url_prefixes` which permits configuring the Gitlab producer so a more relaxed URL matching is performed.

In reality this is totally unnecessary, it's just a workaround for a [Gitlab bug](https://gitlab.com/gitlab-org/gitlab/-/issues/373793).

This (optional) fuzzy matching allows keeping the hints system working even if the declared (and correct) clone URL in the repositories metadata is:

``` 1c-enterprise
  ssh://git@gitlab.example.org:1234/namespace/repo.git
```

and Gitlab incorrectly (see bug above) reports the `git_ssh_url` as:

``` 1c-enterprise
  git@gitlab.example.org:namespace/repo.git

```

with a configuration like:

``` ini
[gitlabproducer]
fuzzy_url_prefixes = git@gitlab.example.org:
```

CERN's internal ticket ref: [AI-6211](https://its.cern.ch/jira/browse/AI-6211)