### PR TITLE
Change HTTP status codes when processing hints

### DIFF
--- a/jens/webapps/gitlabproducer.py
+++ b/jens/webapps/gitlabproducer.py
@@ -62,7 +62,7 @@ def hello_gitlab():
         return 'Queue not accessible', 500
     except NameError as error:
         logging.error("'%s' couldn't be found in repositories" % (url))
-        return 'Repository not found', 404
+        return 'Repository not found', 200
     except Exception as error:
         logging.error("Unexpected error (%s)" % repr(error))
         return 'Internal Server Error!', 500

--- a/jens/webapps/gitlabproducer.py
+++ b/jens/webapps/gitlabproducer.py
@@ -55,7 +55,7 @@ def hello_gitlab():
                     partition, name = _partition, _name
 
         enqueue_hint(partition, name)
-        return 'OK'
+        return 'OK', 201
     except JensMessagingError as error:
         logging.error("%s/%s couldn't be added to the queue (%s)" %
             (partition, name, str(error)))

--- a/jens/webapps/test/test_gitlabproducer.py
+++ b/jens/webapps/test/test_gitlabproducer.py
@@ -60,7 +60,7 @@ class GitlabProducerTestCase(JensTestCase):
                         }
                     }))
         mock_eq.assert_called_once_with('common', 'site')
-        self.assertEqual(reply.status_code, 200)
+        self.assertEqual(reply.status_code, 201)
 
     @patch('jens.webapps.gitlabproducer.enqueue_hint', side_effect=JensMessagingError)
     def test_queue_error(self, mock_eq):
@@ -99,7 +99,7 @@ class GitlabProducerTestCase(JensTestCase):
                               headers={'X-Gitlab-Token': 'tokenvalue'},
                               data=json.dumps(_payload))
         mock_eq.assert_called_once_with('common', 'site')
-        self.assertEqual(reply.status_code, 200)
+        self.assertEqual(reply.status_code, 201)
 
     def test_wrong_secret_token(self):
         self.settings.GITLAB_PRODUCER_SECRET_TOKEN = 'expected'
@@ -142,4 +142,4 @@ class GitlabProducerTestCase(JensTestCase):
                               headers={'X-Gitlab-Token': 'expected'},
                               data=json.dumps(_payload))
         mock_eq.assert_called_once_with('common', 'site')
-        self.assertEqual(reply.status_code, 200)
+        self.assertEqual(reply.status_code, 201)

--- a/jens/webapps/test/test_gitlabproducer.py
+++ b/jens/webapps/test/test_gitlabproducer.py
@@ -83,7 +83,7 @@ class GitlabProducerTestCase(JensTestCase):
                          'git_ssh_url': "file://foo"
                         }
                     }))
-        self.assertEqual(reply.status_code, 404)
+        self.assertEqual(reply.status_code, 200)
 
     @patch('jens.webapps.gitlabproducer.enqueue_hint')
     def test_secret_token_ignored_if_not_configured(self, mock_eq):


### PR DESCRIPTION
## Return 200 if the hinted repository is not found

This is contrary to what we should be logically doing but Gitlab considers hooks returning non-2xx as failed. It should be fine to say "we don't know about this repository" via HTTP status codes, but c'est la vie, I guess.

This plus [gitlab/387938](https://gitlab.com/gitlab-org/gitlab/-/issues/387938) are a recipe for disaster. Anyway, even if this was not the case disabling the hook for 10 minutes is still unacceptable for Jens.

The workaround is to return 2xx, even in this case.

## Return 201 when the hint is enqueued

This is basically to continue to be able to distinguish between known and unknown repositories.